### PR TITLE
Collection of various unrelated fixes, workarounds and hacks

### DIFF
--- a/fpdf_mod/fpdf.py
+++ b/fpdf_mod/fpdf.py
@@ -1322,6 +1322,9 @@ class FPDF(object):
                 dest = "F"
         if PY3K:
             # manage binary data as latin1 until PEP461 or similar is implemented
+            self.buffer = self.buffer.replace('\u0300', '')      # FIXME: ignore COMBINING GRAVE ACCENT: https://www.fileformat.info/info/unicode/char/0300/index.htm
+            self.buffer = self.buffer.replace('\u0301', '')      # FIXME: ignore COMBINING ACUTE ACCENT: https://www.fileformat.info/info/unicode/char/0300/index.htm
+            self.buffer = self.buffer.replace('\u2028', '\n')    # FIXME: replace LINE SEPARATOR: https://www.fileformat.info/info/unicode/char/2028/index.htm
             buffer = self.buffer.encode("latin1")
         else:
             buffer = self.buffer

--- a/slackchannel2pdf/channel_exporter.py
+++ b/slackchannel2pdf/channel_exporter.py
@@ -136,6 +136,11 @@ class SlackChannelExporter:
                 user_id = None
                 user_name = None
 
+        elif msg.get('type') == 'message' and 'username' in msg:   # example message: {'type': 'message', 'subtype': 'bot_message', 'text': 'Foo, bar!', 'ts': '1410478437.000000', 'username': 'John Doe'}
+            is_bot = False    # should this be True, because msg['subtype']=='bot_message'? I don't understand why it has that status, as this message has been written by a human. It might have been imported from an older chat system, however.
+            user_id = None
+            user_name = msg['username']
+
         else:
             is_bot = False
             user_id = None

--- a/slackchannel2pdf/channel_exporter.py
+++ b/slackchannel2pdf/channel_exporter.py
@@ -439,13 +439,28 @@ class SlackChannelExporter:
                             settings.FONT_FAMILY_DEFAULT,
                             size=settings.FONT_SIZE_NORMAL,
                         )
-                        document.write_html(
-                            settings.LINE_HEIGHT_DEFAULT,
-                            self._transformer.transform_text(
-                                layout_block["text"]["text"],
-                                layout_block["text"]["type"] == "mrkdwn",
-                            ),
-                        )
+
+                        if 'text' in layout_block:
+                            document.write_html(
+                                settings.LINE_HEIGHT_DEFAULT,
+                                self._transformer.transform_text(
+                                    layout_block["text"]["text"],
+                                    layout_block["text"]["type"] == "mrkdwn",
+                                ),
+                            )
+                        elif 'fields' in layout_block:
+                            for field in layout_block['fields']:
+                                document.write_html(
+                                    settings.LINE_HEIGHT_DEFAULT,
+                                    self._transformer.transform_text(
+                                        field["text"],
+                                        field["type"] == "mrkdwn",
+                                    ),
+                                )
+
+                        else:
+                            raise Exception('Section without text or fields, no idea what to do')
+
                         document.ln()
 
                         if "fields" in layout_block:

--- a/slackchannel2pdf/channel_exporter.py
+++ b/slackchannel2pdf/channel_exporter.py
@@ -798,6 +798,19 @@ class SlackChannelExporter:
                 fname="NotoSansMono-Bold.ttf",
                 uni=True,
             )
+            # new aliases for ITALIC and ITALIC/BOLD style variants of the mono font: we don't actually have special fonts for this, but will just ignore the italics requirement
+            document.add_font(
+                settings.FONT_FAMILY_MONO_DEFAULT,
+                style="I",
+                fname="NotoSansMono-Regular.ttf",
+                uni=True,
+            )
+            document.add_font(
+                settings.FONT_FAMILY_MONO_DEFAULT,
+                style="IB",
+                fname="NotoSansMono-Bold.ttf",
+                uni=True,
+            )
             document.alias_nb_pages()
             document.add_page()
 

--- a/slackchannel2pdf/cli.py
+++ b/slackchannel2pdf/cli.py
@@ -74,7 +74,8 @@ def main():
 
     if not args.quiet:
         channel_postfix = "s" if args.channel and len(args.channel) > 1 else ""
-        print(f"Exporting channel{channel_postfix} from Slack...")
+        channel_names = ', '.join(['#'+channel_name for channel_name in args.channel])
+        print(f"Exporting channel{channel_postfix} {channel_names} from Slack...")
     try:
         exporter = SlackChannelExporter(
             slack_token=slack_token,

--- a/slackchannel2pdf/fpdf_ext.py
+++ b/slackchannel2pdf/fpdf_ext.py
@@ -59,7 +59,7 @@ class FPDF_ext(fpdf_mod.FPDF):
         # split html into parts to identify all HTML tags
         # even numbered parts will contain text
         # odd numbered parts will contain tags
-        parts = re.split(r"<([^>]*)>", html)
+        parts = re.split(r"<([^>]+)>", html)
 
         # run through all parts one by one
         try:

--- a/slackchannel2pdf/fpdf_ext.py
+++ b/slackchannel2pdf/fpdf_ext.py
@@ -109,7 +109,8 @@ class FPDF_ext(fpdf_mod.FPDF):
 
         if tag == "S":
             if self._last_font is not None:
-                raise HtmlConversionError("<s> tags can not be nested")
+                pass   # FIXME: YOLO, what's the worst that can happen...
+                # raise HtmlConversionError("<s> tags can not be nested")
 
             self._last_font = {
                 "font_family": self.font_family,

--- a/slackchannel2pdf/slack_service.py
+++ b/slackchannel2pdf/slack_service.py
@@ -146,6 +146,13 @@ class SlackService:
             logger.info("This workspace has no usergroups")
         return usergroup_names
 
+    def fetch_permalink(self, channel_id, message_ts) -> str:
+        response = self._client.chat_getPermalink(channel=channel_id, message_ts=message_ts)
+        if response.data['ok']:
+            return response.data['permalink']
+        else:
+            raise Exception('Could not determine permalink: %s', repr(response.data))
+
     def fetch_messages_from_channel(
         self, channel_id, max_messages, oldest=None, latest=None
     ) -> list:


### PR DESCRIPTION
I am fully aware that this isn't a 'merge as seen' PR. It's more of an unsorted collection of hacks and workarounds that I applied to my local fork of slackchannel2pdf to quickly run the one-time archive I needed to complete.

Mostly, this was me running my archive tasks in a debugger until an exception was raised, then hacking something into those lines without any real comprehension of the wider context my changes operated in.

I'm sorry, but I don't have the time to clean these up and fully develop them right now. I still wanted to contribute them in some way, hoping it might help someone get started and really polish them into a releaseable state. As such, I'm also not offended if you just close this PR.

I did carefully group my changes by commit, and spent some effort on the commit messages, so I recommend reading them by commit. They also contain example stack traces where applicable.

The main change is possibly the fix for the rate limiting exceptions, which I got pretty reliably for almost every non-trivial channel. Always on the pagination function, somewhere when retrieving messages, I believe (but didn't preserve the specific stack traces). My solution isn't very elegant, but I never experienced any issues with rate limiting again.
There's probably other, non-`_fetch_pages`-based calls that should receive the same treatment, but I didn't experience them, so I didn't go searching either.

I hereby put all my changes under the MIT license, and you're free to use, modify, sell or ignore them in any way you see fit. 😀